### PR TITLE
fix/feat: collect additional album img

### DIFF
--- a/album_main.py
+++ b/album_main.py
@@ -14,14 +14,14 @@ from src.utils import resizeImg
 @hydra.main(version_base="1.2", config_path="configs", config_name="config.yaml")
 def main(config: DictConfig = None) -> None:
     file_path = config.out_dir
-    playlist_file = "playlists.csv"
-    song_file = "songs.csv"
+    playlist_file = config.pl_concat
+    song_file = config.song_concat
 
     pl_df = pd.read_csv(os.path.join(file_path, playlist_file))
     song_df = pd.read_csv(os.path.join(file_path, song_file))
 
-    non_album_ids = list(song_df[song_df["IMG_PATH"].apply(lambda x: not bool(re.search(".png|.JPG|.PNG|.jpg", x)))]["ALBUM_ID"])
-    album_url = "https://www.genie.co.kr/detail/albumInfo?axnm="
+    non_album_ids = list(set(song_df[song_df["IMG_PATH"].apply(lambda x: not bool(re.search(".png|.JPG|.PNG|.jpg", x)))]["ALBUM_ID"]))
+    album_url = config.album_url
 
     album_img_list = []
     for id in tqdm(non_album_ids):
@@ -35,7 +35,9 @@ def main(config: DictConfig = None) -> None:
 
         details = driver.find_element(By.CLASS_NAME, "album-detail-infos")
         photo = details.find_element(By.CLASS_NAME, "photo-zone")
-        img_path = (photo.find_element(By.TAG_NAME, "a")).get_attribute("href")
+        img = (photo.find_element(By.CLASS_NAME, "thum")).find_element(By.TAG_NAME, "a")
+
+        img_path = img.get_attribute("href")
         resized_img_path = resizeImg(img_path[: img_path.find("/dims")], config.img_resize, config.max_resize)
 
         info = {
@@ -49,7 +51,7 @@ def main(config: DictConfig = None) -> None:
 
     album_img_df = pd.DataFrame(album_img_list)
 
-    new_album_img_path = os.path.join(file_path, "new_album_imgs.csv")
+    new_album_img_path = os.path.join(file_path, config.album_img_filename)
     album_img_df.to_csv(new_album_img_path, index=False)
 
 

--- a/album_main.py
+++ b/album_main.py
@@ -1,0 +1,57 @@
+import os
+import re
+import hydra
+import pandas as pd
+from tqdm import tqdm
+from omegaconf import DictConfig
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+from src.utils import resizeImg
+
+
+@hydra.main(version_base="1.2", config_path="configs", config_name="config.yaml")
+def main(config: DictConfig = None) -> None:
+    file_path = config.out_dir
+    playlist_file = "playlists.csv"
+    song_file = "songs.csv"
+
+    pl_df = pd.read_csv(os.path.join(file_path, playlist_file))
+    song_df = pd.read_csv(os.path.join(file_path, song_file))
+
+    non_album_ids = list(song_df[song_df["IMG_PATH"].apply(lambda x: not bool(re.search(".png|.JPG|.PNG|.jpg", x)))]["ALBUM_ID"])
+    album_url = "https://www.genie.co.kr/detail/albumInfo?axnm="
+
+    album_img_list = []
+    for id in tqdm(non_album_ids):
+        link = album_url + str(id)
+
+        op = webdriver.ChromeOptions()
+        op.add_argument("--headless")
+
+        driver = webdriver.Chrome(options=op)
+        driver.get(url=link)
+
+        details = driver.find_element(By.CLASS_NAME, "album-detail-infos")
+        photo = details.find_element(By.CLASS_NAME, "photo-zone")
+        img_path = (photo.find_element(By.TAG_NAME, "a")).get_attribute("href")
+        resized_img_path = resizeImg(img_path[: img_path.find("/dims")], config.img_resize, config.max_resize)
+
+        info = {
+            "ALBUM_ID": id,
+            "IMG_PATH": resized_img_path,
+        }
+        print(f"ALBUM_ID: {id} / IMG_PATH {resized_img_path} ... ")
+
+        album_img_list.append(info)
+        driver.close()
+
+    album_img_df = pd.DataFrame(album_img_list)
+
+    new_album_img_path = os.path.join(file_path, "new_album_imgs.csv")
+    album_img_df.to_csv(new_album_img_path, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/concat.py
+++ b/concat.py
@@ -1,7 +1,11 @@
 import os
+import hydra
 import pandas as pd
+from omegaconf import DictConfig
 
-if __name__ == "__main__":
+
+@hydra.main(version_base="1.2", config_path="configs", config_name="config.yaml")
+def main(config: DictConfig = None) -> None:
     # Concat total file
     file_path = "./outputs/"
     files = [file for file in os.listdir(file_path) if ".csv" in file]
@@ -15,7 +19,11 @@ if __name__ == "__main__":
             songs.append(pd.read_csv(os.path.join(file_path, file)))
 
     playlists_df = pd.concat(playlists)
-    playlists_df.to_csv(os.path.join(file_path, "playlists.csv"), index=False)
+    playlists_df.to_csv(os.path.join(file_path, config.pl_concat), index=False)
 
     songs_df = pd.concat(songs)
-    songs_df.to_csv(os.path.join(file_path, "songs.csv"), index=False)
+    songs_df.to_csv(os.path.join(file_path, config.song_concat), index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/concat.py
+++ b/concat.py
@@ -1,0 +1,21 @@
+import os
+import pandas as pd
+
+if __name__ == "__main__":
+    # Concat total file
+    file_path = "./outputs/"
+    files = [file for file in os.listdir(file_path) if ".csv" in file]
+    files = sorted(files, key=lambda x: int(x[: x.find("_")]))
+
+    playlists, songs = [], []
+    for file in files:
+        if "pl_info" in file:
+            playlists.append(pd.read_csv(os.path.join(file_path, file)))
+        else:
+            songs.append(pd.read_csv(os.path.join(file_path, file)))
+
+    playlists_df = pd.concat(playlists)
+    playlists_df.to_csv(os.path.join(file_path, "playlists.csv"), index=False)
+
+    songs_df = pd.concat(songs)
+    songs_df.to_csv(os.path.join(file_path, "songs.csv"), index=False)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,6 +1,7 @@
 # url path of genie
 playlist_origin_url: https://www.genie.co.kr/playlist/popular?sortOrd=RDD
 playlist_url: https://www.genie.co.kr/playlist/detailView?plmSeq=
+album_url: https://www.genie.co.kr/detail/albumInfo?axnm=
 
 # file path
 out_dir: outputs/
@@ -9,11 +10,16 @@ log_dir: logs/
 # csv file name
 pl_filename: pl_info.csv
 song_filename: song_info.csv
+album_img_filename: new_album_imgs.csv
+
+# concat file name
+pl_concat: playlists.csv
+song_concat: songs.csv
 
 # img resize option
 img_resize: 140
 max_resize: 600
 
 # retrival scope 
-start_idx: 15525
-end_idx: 
+start_idx: 9001
+end_idx: 10000


### PR DESCRIPTION
## Overview
- 곡 데이터의 앨범 이미지가 잘못된 경로를 가질 경우를 고려하여 이를 새로 가져올 수 있도록 하는 코드를 추가하였습니다

## Change Log
- 앨범 페이지를 이용하여 앨범 커버 이미지의 경로를 가져오는 코드 파일을 추가하였습니다 (`album_main.py`)
- 크롤링한 플리/곡 파일이 여러 개 있을 경우 하나로 합쳐주는 코드 파일을 추가하였습니다(`concat.py`)
- 두 코드파일에서 모두 hydra를 사용할 수 있도록 하였습니다

## To Reviewer
-  concat 작업에 대해서 PR을 날리지 않아, issue(#12 )에 적힌 작업과 concat 작업까지 함께 PR을 날리게 되었습니다

## Issue Tags
- Closed: #12 