### PR TITLE
IMR-62 fix : 음악 상세정보 크롤링 오류 수정

### DIFF
--- a/song_detail_main.py
+++ b/song_detail_main.py
@@ -41,8 +41,7 @@ def main(config: DictConfig = None) -> None:
     csv_path = os.path.join(config.out_dir, config.song_detail_filename)
     log.info("Save concatencated song_info to %s", csv_path)
     song_details_df = pd.DataFrame(song_details)
-    concatenated_df = song_details_df.set_index("SONG_ID").join(song_info_df.set_index("SONG_ID"), on="SONG_ID", how="left")
-    concatenated_df.to_csv(csv_path)
+    song_details_df.to_csv(csv_path)
 
 
 if __name__ == "__main__":

--- a/src/song_detail/song_daliy_chart_crawler.py
+++ b/src/song_detail/song_daliy_chart_crawler.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup, Tag
+from utils import txt2int
 
 SONG_DAILY_CHART_SELECTOR = ".daily-chart div.total"
 SONG_DAILY_CHART_LISTENER_CNT_SELECTOR = "div:nth-child(1) p"
@@ -6,11 +7,11 @@ SONG_DAILY_CHART_PLAY_CNT_SELECTOR = "div:nth-child(2) p"
 
 
 def parseListenerCnt(listener_cnt_el: Tag) -> int:
-    return int(listener_cnt_el.text.replace(",", ""))
+    return txt2int(listener_cnt_el.text)
 
 
 def parsePlayCnt(play_cnt_el: Tag) -> int:
-    return int(play_cnt_el.text.replace(",", ""))
+    return txt2int(play_cnt_el.text)
 
 
 def crawlSongDailyChart(soup: BeautifulSoup) -> tuple[int, int]:

--- a/src/song_detail/song_daliy_chart_crawler.py
+++ b/src/song_detail/song_daliy_chart_crawler.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup, Tag
-from utils import txt2int
+from src.utils import txt2int
 
 SONG_DAILY_CHART_SELECTOR = ".daily-chart div.total"
 SONG_DAILY_CHART_LISTENER_CNT_SELECTOR = "div:nth-child(1) p"

--- a/src/song_detail/song_like_crawler.py
+++ b/src/song_detail/song_like_crawler.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from utils import txt2int
+from src.utils import txt2int
 
 SONG_LIKE_SELECTOR = "a.like em#emLikeCount"
 

--- a/src/song_detail/song_like_crawler.py
+++ b/src/song_detail/song_like_crawler.py
@@ -1,10 +1,10 @@
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup
+from utils import txt2int
 
 SONG_LIKE_SELECTOR = "a.like em#emLikeCount"
 
 
 def crawlSongLike(soup: BeautifulSoup) -> int:
     song_like_el = soup.select_one(SONG_LIKE_SELECTOR)
-    song_like = int(song_like_el.text)
 
-    return song_like
+    return txt2int(song_like_el.text)

--- a/src/utils.py
+++ b/src/utils.py
@@ -109,7 +109,7 @@ def tranlateSongInfoAttrToEng(attr: str) -> str:
 def txt2int(txt: str) -> int:
     removed_txt = txt.replace(",", "")
 
-    if removed_txt:
+    if not removed_txt:
         return 0
 
     return int(removed_txt)

--- a/src/utils.py
+++ b/src/utils.py
@@ -104,3 +104,12 @@ def tranlateSongInfoAttrToEng(attr: str) -> str:
     }
 
     return ATTR_URL_TO_ENG[attr]
+
+
+def txt2int(txt: str) -> int:
+    removed_txt = txt.replace(",", "")
+
+    if removed_txt:
+        return 0
+
+    return int(removed_txt)


### PR DESCRIPTION
## Overview
- `song_like_crawler.py` 에서 아래와 같은 오류가 생겨 일부 음악의 상세정보를 가져오지 못했습니다.
```
[2023-07-06 16:47:21,113][root][ERROR] - invalid literal for int() with base 10: ''
Traceback (most recent call last):
  File "/opt/ml/genie_crawler/song_detail_main.py", line 31, in main
    song_detail = crawlSongDetail(song_id, config.song_detail_url, log)
  File "/opt/ml/genie_crawler/src/song_detail_crawler.py", line 25, in crawlSongDetail
    log.info("lyrics : %s", textwrap.shorten(lyrics, width=50, placeholder="...") if lyrics else lyrics)
  File "/opt/ml/genie_crawler/src/song_detail/song_like_crawler.py", line 8, in crawlSongLike
ValueError: invalid literal for int() with base 10: ''
```

## Change Log
- song_like_crawler의 text to int 메서드 작성
- song info에 merge 하지 않고 song detail info 파일을 새로 생성하게 함.

## See also
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-62)