### PR TITLE
IMR-78 fix : 음악 상세 정보 크롤링 장르 못가져오는 오류 수정

### DIFF
--- a/src/song_detail/song_info_crawler.py
+++ b/src/song_detail/song_info_crawler.py
@@ -15,7 +15,7 @@ def parseSongInfoData(song_info_data_el: Tag) -> list[dict[str, str]]:
     Returns:
         list[dict[str, str]]: 음악 정보 목록
     """
-    song_info_item_els: ResultSet[Tag] = song_info_data_el.findChildren("li", recursive=False)
+    song_info_item_els: ResultSet[Tag] = song_info_data_el.findChildren("li")
     song_info_data = {}
 
     for song_info_item_el in song_info_item_els:

--- a/src/song_detail/song_info_crawler.py
+++ b/src/song_detail/song_info_crawler.py
@@ -19,6 +19,9 @@ def parseSongInfoData(song_info_data_el: Tag) -> list[dict[str, str]]:
     song_info_data = {}
 
     for song_info_item_el in song_info_item_els:
+        if song_info_item_el.parent is not song_info_data_el:
+            continue
+
         attr, value = parseSongInfoItem(song_info_item_el)
         song_info_data[attr] = value
 


### PR DESCRIPTION
## Overview
- 음악 상세 정보 크롤링 장르 못가져오는 오류 수정

## Change Log
- `ul.info-data`의 자식 태그 `li`를 하나만 가져오는 것을 모두 가져오게 변경
- `ul.info-data`의 자식 태그 `li`는 직속자식만 크롤링 대상임

## Issue Tags
- See [also](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-78)