### PR TITLE
IMR-178 fix: checking song docs length and apply literal_eval to change "list[str]" to list[str]

### DIFF
--- a/src/crawler/playlist_main.py
+++ b/src/crawler/playlist_main.py
@@ -29,7 +29,7 @@ def crawlPlaylist() -> (pd.DataFrame, pd.DataFrame):
     err_list = []
 
     # start searching
-    for id in tqdm(range(15725, 15725 + 1)):
+    for id in tqdm(range(start_idx - 10, end_idx + 10)):
         try:
             pl_url = PLAYLIST_URL + str(id)
             pl_info = getPlaylistInfo(id, pl_url, config, songs_list, log)

--- a/src/migration/crawler.py
+++ b/src/migration/crawler.py
@@ -85,4 +85,5 @@ class CrawlerMigrate:
                 songs = self.find_song_docs(self.pl_df.iloc[idx]["PLAYLIST_SONGS"])
                 song_cnt = len(songs)
 
-                self.playlist_repository.create_playlist(id, title, subtitle, song_cnt, like_cnt, view_cnt, tags, songs, img_url)
+                if song_cnt:
+                    self.playlist_repository.create_playlist(id, title, subtitle, song_cnt, like_cnt, view_cnt, tags, songs, img_url)

--- a/src/migration/playlist.py
+++ b/src/migration/playlist.py
@@ -31,7 +31,7 @@ class PlaylistCsvMigrate:
                 subtitle = pl_df.iloc[idx]["playlist_subtitle"]
                 like_cnt = pl_df.iloc[idx]["playlist_likecount"]
                 view_cnt = pl_df.iloc[idx]["playlist_view"]
-                tags = pl_df.iloc[idx]["playlist_tags"]
+                tags = ast.literal_eval(pl_df.iloc[idx]["playlist_tags"])
                 img_url = pl_df.iloc[idx]["playlist_img_url"]
                 songs = self.find_song_docs(ast.literal_eval(pl_df.iloc[idx]["playlist_songs"]))
                 song_cnt = len(songs)

--- a/src/migration/playlist.py
+++ b/src/migration/playlist.py
@@ -6,7 +6,7 @@ import ast
 
 class PlaylistCsvMigrate:
     def __init__(self, path: str):
-        self.df = pd.read_csv(path)
+        self.df = pd.read_csv(path, dtype={"playlist_id": str})
         self.song_repository = SongRepository()
         self.playlist_repository = PlaylistRepository()
 

--- a/src/migration/playlist.py
+++ b/src/migration/playlist.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from src.db import SongRepository, PlaylistRepository, Song
 from tqdm import tqdm
+import ast
 
 
 class PlaylistCsvMigrate:
@@ -32,7 +33,7 @@ class PlaylistCsvMigrate:
                 view_cnt = pl_df.iloc[idx]["playlist_view"]
                 tags = pl_df.iloc[idx]["playlist_tags"]
                 img_url = pl_df.iloc[idx]["playlist_img_url"]
-                songs = self.find_song_docs(pl_df.iloc[idx]["playlist_songs"])
+                songs = self.find_song_docs(ast.literal_eval(pl_df.iloc[idx]["playlist_songs"]))
                 song_cnt = len(songs)
 
                 if song_cnt:

--- a/src/migration/playlist.py
+++ b/src/migration/playlist.py
@@ -35,4 +35,5 @@ class PlaylistCsvMigrate:
                 songs = self.find_song_docs(pl_df.iloc[idx]["playlist_songs"])
                 song_cnt = len(songs)
 
-                self.playlist_repository.create_playlist(id, title, subtitle, song_cnt, like_cnt, view_cnt, tags, songs, img_url)
+                if song_cnt:
+                    self.playlist_repository.create_playlist(id, title, subtitle, song_cnt, like_cnt, view_cnt, tags, songs, img_url)


### PR DESCRIPTION
## Overview
- playlist의 곡이 0개인 경우 playlist doc을 생성할 수 없어 오류가 발생해 해당 부분을 방지하기 위해 doc 생성 전 song docs 길이를 확인합니다.
- 더불어 playlist csv에 저장된 song_list 및 tag_list가 "list[str]"과 같은 형태로 되어 있어 이를 해결합니다.

## Change Log
- 테스트로 수정해두었던 범위 복구
- 노래 길이 체크 추가
- literal_eval을 통해 "list[str]" -> list[str]

## To Reviewer
- 해당 부분 테스트하며 마지막 크롤링 이후의 데이터도 전부 디비에 추가하였습니당

## Issue Tags
- [Jira issue](https://btcamplevel3.atlassian.net/browse/IMR-178?atlOrigin=eyJpIjoiODhkZWMwOTcwNDcxNGQzMGIyZGQxMmFmZDczNzQxZDQiLCJwIjoiaiJ9)
